### PR TITLE
feat: hide error if no tilt server is started

### DIFF
--- a/tilt-status-prompt.sh
+++ b/tilt-status-prompt.sh
@@ -11,7 +11,10 @@ __tilt_ps1()
     die "error: jq not on path"
   fi
   
-  STATUS_JSON="$(tilt get session -ojson)"
+  STATUS_JSON="$(tilt get session -ojson 2> /dev/null)"
+  if [[ $? != 0 ]]; then
+    exit 0
+  fi
   
   # echo "$STATUS_JSON" | jq -C '.'
   RESOURCE_STATUSES="$(echo "$STATUS_JSON" | jq -r '.items[].status.targets[] | "\(.name) \(.type) \(.state | keys[0]) \(.state.terminated | has("error")) \(.state.active.ready)"')"


### PR DESCRIPTION
Hello,

I suggest this usage : when your tilt server is started, you shell displays information tilt state, but in another case, shell hides the tilt part to avoid to display too much information.
What to you think ?

Additional question, the PS1 is generated at the start of the shell and data are not updated, I have to start another shell (or source it). It makes sense and I am not an expert with this. Is it a way to update the PS1 in live ? ^^

Thank you for your amazing work ! <3

